### PR TITLE
Allow overflowing items to wrap

### DIFF
--- a/src/IndicatorChart.tsx
+++ b/src/IndicatorChart.tsx
@@ -32,7 +32,8 @@ export default function IndicatorChart(chartProps: ChartProps) {
             flexDirection: 'column',
             flexWrap: 'wrap'
             alignItems: 'center',
-            justifyContent: 'center',
+            alignContent: 'space-between',
+            justifyContent: 'space-between',
             backgroundColor: backgroundColors[index],
             borderRadius: roundedCorners ? '0.5em' : 0,
             color: textColor === 'light' ? 'gainsboro' : '#404040',

--- a/src/IndicatorChart.tsx
+++ b/src/IndicatorChart.tsx
@@ -39,6 +39,7 @@ export default function IndicatorChart(chartProps: ChartProps) {
             color: textColor === 'light' ? 'gainsboro' : '#404040',
             marginBottom: orientation === 'horizontal' ? 0 : 10,
             marginRight: orientation === 'horizontal' ? 10 : 0,
+            padding: '1ex',
           }}
         >
           <SafeMarkdown source={markdown} />

--- a/src/IndicatorChart.tsx
+++ b/src/IndicatorChart.tsx
@@ -30,6 +30,7 @@ export default function IndicatorChart(chartProps: ChartProps) {
             flex: 1,
             display: 'flex',
             flexDirection: 'column',
+            flexWrap: 'wrap'
             alignItems: 'center',
             justifyContent: 'center',
             backgroundColor: backgroundColors[index],


### PR DESCRIPTION
If there are more elements than what can fit in the chart area, the additional ones overflow the single row/column:

![Screenshot from 2022-01-27 13-27-19](https://user-images.githubusercontent.com/37387755/151368182-c232e339-26ac-4311-b181-84689c0d8852.png)


Here, we allow them to wrap into multiple rows/columns:

![Screenshot from 2022-01-27 13-25-29](https://user-images.githubusercontent.com/37387755/151367988-1b2c0f48-824e-4a9f-b5f9-4c69e8f4664e.png)
